### PR TITLE
Do not verify _data against NULL

### DIFF
--- a/EnumReflection.cpp
+++ b/EnumReflection.cpp
@@ -91,8 +91,7 @@ EnumReflector::EnumReflector(const int* vals, int count, const char* name, const
 
 EnumReflector::~EnumReflector()
 {
-    if(_data)
-        delete _data;
+    delete _data;
 }
 
 int EnumReflector::Count() const


### PR DESCRIPTION
`_data` cannot be NULL - on memory allocation failure, the `bad_alloc` exception will be thrown.
